### PR TITLE
feat: Support integer and byte slice value for SetNetwork()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module pifke.org/wpasupplicant
+
+go 1.16

--- a/unixgram_test.go
+++ b/unixgram_test.go
@@ -44,14 +44,14 @@ var parseScanResultTests = []struct {
 			"8a:15:14:8a:46:51\t5560\t-58\t[WPA-PSK-CCMP+TKIP][WPA2-PSK-CCMP+TKIP][ESS]\tWIP-Backoffice\n" +
 			"8a:15:14:8a:46:50\t5560\t-58\t[WPA-PSK-CCMP+TKIP][WPA2-PSK-CCMP+TKIP][ESS]\tWorkInProgressMember\n",
 		expect: []*scanResult{
-			&scanResult{
+			{
 				bssid:     net.HardwareAddr{0x8a, 0x15, 0x14, 0x8a, 0x46, 0x51},
 				frequency: 5560,
 				rssi:      -58,
 				flags:     []string{"WPA-PSK-CCMP+TKIP", "WPA2-PSK-CCMP+TKIP", "ESS"},
 				ssid:      "WIP-Backoffice",
 			},
-			&scanResult{
+			{
 				bssid:     net.HardwareAddr{0x8a, 0x15, 0x14, 0x8a, 0x46, 0x50},
 				frequency: 5560,
 				rssi:      -58,
@@ -66,12 +66,12 @@ var parseScanResultTests = []struct {
 			"5560\t8a:15:14:8a:46:51\thello\tWIP-Backoffice\n" +
 			"5560\t8a:15:14:8a:46:50\tgoodbye\tWorkInProgressMember\n",
 		expect: []*scanResult{
-			&scanResult{
+			{
 				bssid:     net.HardwareAddr{0x8a, 0x15, 0x14, 0x8a, 0x46, 0x51},
 				frequency: 5560,
 				ssid:      "WIP-Backoffice",
 			},
-			&scanResult{
+			{
 				bssid:     net.HardwareAddr{0x8a, 0x15, 0x14, 0x8a, 0x46, 0x50},
 				frequency: 5560,
 				ssid:      "WorkInProgressMember",
@@ -93,7 +93,7 @@ func TestParseScanResults(t *testing.T) {
 
 		for i := range output {
 			if test.expect[i].bssid != nil {
-				if bytes.Compare(output[i].BSSID(), test.expect[i].bssid) != 0 {
+				if !bytes.Equal(output[i].BSSID(), test.expect[i].bssid) {
 					t.Errorf("wrong bssid (got %q, expect %q)", output[i].BSSID(), test.expect[i].bssid)
 				}
 			}

--- a/wpasupplicant.go
+++ b/wpasupplicant.go
@@ -190,22 +190,26 @@ type Conn interface {
 
 	// SetNetwork configures a network property. Returns error if the property
 	// configuration failed.
-	SetNetwork(int, string, string) error
+	// Value's type must one of int, string and []byte. The int type always shown
+	// without double quotes. The string type always shown with double quotes except
+	// the variable name is key_mgmt. The []byte type only uses for ssid, maybe useful
+	// when it contains non-ascii encoded chars.
+	SetNetwork(networkID int, variable string, value interface{}) error
 
 	// EnableNetwork enables a network. Returns error if the command fails.
-	EnableNetwork(int) error
+	EnableNetwork(networkID int) error
 
 	// EnableAllNetworks enables all configured networks. Returns error if the command fails.
 	EnableAllNetworks() error
 
 	// SelectNetwork selects a network (and disables the others).
-	SelectNetwork(int) error
+	SelectNetwork(networkID int) error
 
 	// DisableNetwork disables a network.
-	DisableNetwork(int) error
+	DisableNetwork(networkID int) error
 
 	// RemoveNetwork removes a network from the configuration.
-	RemoveNetwork(int) error
+	RemoveNetwork(networkID int) error
 
 	// RemoveAllNetworks removes all networks (basically running `REMOVE_NETWORK all`).
 	// Returns error if command fails.


### PR DESCRIPTION
With these changes, we can launch an Access Point by using wpa_supplicant.

```
conn.SetNetwork(0, "ssid", "test-access-point") // hex encoded ssid is not tested, hope someone can improve it.
conn.SetNetwork(0, "key_mgmt", "WPA-PSK")
conn.SetNetwork(0, "psk", "12345678")
conn.SetNetwork(0, "mode", 2) // we have to set mode to 2 without double quotes, so we need support integer value.
conn.SetNetwork(0, "frequency", 2414)
conn.EnableNetwork(0)
```