### PR TITLE
Add timeout support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module pifke.org/wpasupplicant
+
+go 1.13

--- a/wpasupplicant.go
+++ b/wpasupplicant.go
@@ -35,6 +35,7 @@ package wpasupplicant
 
 import (
 	"net"
+	"time"
 )
 
 // Cipher is one of the WPA_CIPHER constants from the wpa_supplicant source.
@@ -242,4 +243,12 @@ type Conn interface {
 	ScanResults() ([]ScanResult, []error)
 
 	EventQueue() chan WPAEvent
+
+	// Timeout returns the current timeout value for waiting for command responses
+	// from WPS Supplicant
+	Timeout() time.Duration
+
+	// SetTimeout defines the timeout value of how long to wait for WPA Supplicant
+	// command responses
+	SetTimeout(time.Duration)
 }


### PR DESCRIPTION
When working on this https://github.com/fornellas/wifi_exporter, I've noticed that sometimes `ScanResults()` would hang forever, despite having called `Scan()` and waited for `SCAN-RESULTS` from `EventQueue()`. After some debugging, it became clear that this condition is triggered when a scan is started, and the network interface reconnects to wifi. It seems that the scan state is lost in this situation, and the response never gets back.

This PR adds `Timeout()` and `SetTimeout()` to the interface, so we can define a... timeout that enables to prevent freezing the code in these situations.

Additionally:

- Added a Mutex to prevent concurrent calls to commands.
- Added `go.mod` to [enable the repo to be used a a submodule](https://github.com/fornellas/wifi_exporter/blob/bba7a3c95dcb324c43b01f9045a4c324d6a07459/go.mod#L16).